### PR TITLE
Add initial snapcraft support

### DIFF
--- a/snap/gui/monsterwars.desktop
+++ b/snap/gui/monsterwars.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Monster Wars
+Exec=monsterwars
+Icon=${SNAP}/meta/gui/monsterwars.svg
+Terminal=false
+Type=Application
+X-Ubuntu-Touch=true
+X-Ubuntu-Supported-Orientations=landscape
+

--- a/snap/gui/monsterwars.svg
+++ b/snap/gui/monsterwars.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500"
+   height="500"
+   viewBox="0 0 499.99998 499.99998"
+   id="svg4266"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="MonsterWars.svg"
+   inkscape:export-filename="/home/timon/development/monsterwars/monsterwars/MonsterWars-64x64.png"
+   inkscape:export-xdpi="11.52"
+   inkscape:export-ydpi="11.52">
+  <defs
+     id="defs4268">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4142">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4144" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4146" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4142"
+       id="linearGradient4148"
+       x1="258.59903"
+       y1="870.0423"
+       x2="261.60403"
+       y2="-202.73959"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="144.06922"
+     inkscape:cy="174.34599"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2880"
+     inkscape:window-height="1749"
+     inkscape:window-x="0"
+     inkscape:window-y="51"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4271">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-552.36209)">
+    <rect
+       style="opacity:1;fill:url(#linearGradient4148);fill-opacity:1;stroke:none;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0"
+       id="rect4142"
+       width="500"
+       height="500"
+       x="0"
+       y="552.36206" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:9.05289745;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 159.27209,658.83564 -57.34938,4.59833 39.97081,11.14543 -54.414145,13.65191 35.483915,7.0118 -40.479813,22.73699 26.825233,3.17465 -41.49021,33.91507 28.456298,-2.09951 -31.748961,39.78988 27.404326,-3.71038 -26.6756,49.46852 31.020235,-7.15711 -23.117014,50.72117 34.599266,-17.59364 -17.176961,47.74546 29.590231,-23.14582 -7.2303,63.36448 28.02251,-38.43678 c 0,0 3.41022,44.14565 3.49997,55.39281 0.027,3.38984 28.88762,-33.02604 28.88762,-33.02604 l 14.78278,50.44822 20.48189,-34.76756 23.35598,35.77242 21.91456,-31.30395 29.13681,30.7772 17.73935,-39.11082 c 0,0 37.9808,32.81581 37.9808,31.50367 0,-1.31183 -4.1329,-56.17414 -4.1329,-56.17414 l 44.99806,36.4076 -14.27524,-63.30318 38.4811,24.59968 -20.48188,-60.35119 36.66411,25.67552 -23.63019,-59.78704 37.09053,26.87122 -34.57719,-61.47676 36.59556,12.34494 -39.72955,-54.16234 33.65047,0.40846 -43.89143,-36.15995 25.17709,-4.78993 -47.2106,-26.04164 29.97266,-8.15916 -54.77312,-17.25511 30.97371,-9.05786 -52.10232,-7.18331 27.77636,-12.49356 -56.01653,3.9657 15.41763,-14.97082 c 0,0 -39.52793,11.17382 -40.09845,10.34172 -1.81173,-2.64228 -2.17082,-12.06266 -2.17082,-12.06266 l -26.2519,12.63965 -20.30065,-12.05876 0.39259,16.4434 c 0.0129,0.54379 -33.77568,-13.20955 -33.77568,-13.20955 l 16.17046,17.46894 -45.92757,-10.74584 24.51473,19.27372 -52.92456,-2.61846"
+       id="path4258"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccscccccccsccccccccccccccccccccccscccsccccc"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.27162492;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path4180-94"
+       cx="287.41785"
+       cy="756.70233"
+       rx="39.491463"
+       ry="50.052399"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.21809459;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path4180-2-4"
+       cx="201.13322"
+       cy="749.36688"
+       rx="46.027447"
+       ry="64.0158"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       id="path4199-60"
+       cx="289.21228"
+       cy="767.93817"
+       rx="7.2685218"
+       ry="9.4425306"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       id="path4199-6-10"
+       cx="200.64076"
+       cy="764.35999"
+       rx="8.3185511"
+       ry="10.379635"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.2744019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 201.92301,867.40483 -6.18965,39.59272 32.85112,5.80009 -2.02286,-40.37598 z"
+       id="path4232-06"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.2744019;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 283.40122,869.18337 9.47221,49.44948 -38.32205,5.05452 2.64811,-50.64677 z"
+       id="path4232-1-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.54880381;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 168.1919,851.7622 c 29.45827,23.40959 107.64709,34.32183 156.18025,-2.13591"
+       id="path4228-73"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:export-filename="/home/timon/development/animationTesting/monster-template.png"
+       inkscape:export-xdpi="89.999916"
+       inkscape:export-ydpi="89.999916" />
+  </g>
+</svg>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ version: '0.1'
 summary: Strategy game consisting of a pillow fight between monsters.
 description: |
   Strategy game consisting of a pillow fight between monsters.
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable
 confinement: strict
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: monsterwars
+version: '0.1'
+summary: Strategy game consisting of a pillow fight between monsters.
+description: |
+  Strategy game consisting of a pillow fight between monsters.
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  monsterwars:
+    command: desktop-launch $SNAP/lib/*/bin/MonsterWars
+    plugs:
+     - opengl
+     - pulseaudio
+     - x11
+
+parts:
+  monsterwars:
+    build-packages:
+     - intltool
+     - qt5-default
+     - qt5-qmake
+     - qtdeclarative5-dev
+     - ubuntu-sdk-qmake-extras
+    plugin: qmake
+    source: .  # https://github.com/t-mon/monsterwars
+    stage-packages:
+     - gstreamer1.0-plugins-good
+     - gstreamer1.0-pulseaudio
+     - qml-module-qtmultimedia
+     - qml-module-qtquick-layouts
+     - qml-module-qtquick2
+     - qml-module-ubuntu-thumbnailer0.1
+     - qml-module-ubuntu-components
+    qt-version: qt5
+    after: [desktop-qt5]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,9 +28,9 @@ parts:
      - gstreamer1.0-plugins-good
      - gstreamer1.0-pulseaudio
      - qml-module-qtmultimedia
-     - qml-module-qtquick-layouts
      - qml-module-qtquick2
-     - qml-module-ubuntu-thumbnailer0.1
+     - qml-module-qtquick-layouts
      - qml-module-ubuntu-components
+     - qml-module-ubuntu-thumbnailer0.1
     qt-version: qt5
     after: [desktop-qt5]


### PR DESCRIPTION
Working:
- Packaged as a snap with confinement
- Gameplay
- Sounds
- .desktop, icon

Not working:
- background image (is this supposed to come from thumbnailer?)
- when using mouse and you hover over a character debug info appears? (is there a build flag we can use to remove this?)

Testing:
$ sudo apt install snapcraft snapd
$ snapcraft
$ sudo snap install monsterwars_*.snap --dangerous
$ snap run monsterwars

Notes:
- If you merge this you should be able to use https://build.snapcraft.io/ to auto build the snap and push to the edge channel :-)