### PR TITLE
Fix clickable 5.0 compatibility

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,4 +1,3 @@
 {
-  "template": "qmake",
-  "sdk": "ubuntu-sdk-16.04"
+  "template": "qmake"
 }


### PR DESCRIPTION
The sdk key has been removed in clickable 5.0. Xenial now is the default.